### PR TITLE
Merge branch 'fix/tilde-expansion' into 'main'

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This Repo consists of two main topics
 
 | Method    | Command                                                                                           |
 |:----------|:--------------------------------------------------------------------------------------------------|
-| **curl**  | `env -i sh -c "$(curl -fsSL https://raw.githubusercontent.com/Cerulean-Circle-GmbH/once.sh/main/init/oosh)"` |
-| **wget**  | `env -i sh -c "$(wget -O- https://raw.githubusercontent.com/Cerulean-Circle-GmbH/once.sh/main/init/oosh)"`   |
-| **fetch** | `env -i sh -c "$(fetch -o - https://raw.githubusercontent.com/Cerulean-Circle-GmbH/once.sh/main/init/oosh)"` |
+| **curl**  | `sh -c "$(curl -fsSL https://raw.githubusercontent.com/Cerulean-Circle-GmbH/once.sh/main/init/oosh)"` |
+| **wget**  | `sh -c "$(wget -O- https://raw.githubusercontent.com/Cerulean-Circle-GmbH/once.sh/main/init/oosh)"`   |
+| **fetch** | `sh -c "$(fetch -o - https://raw.githubusercontent.com/Cerulean-Circle-GmbH/once.sh/main/init/oosh)"` |
 
 ## manual install
 ```

--- a/certificates
+++ b/certificates
@@ -72,7 +72,7 @@ certificates.once.get.certbot.path() # # gets the path of the once certificat sc
 
 private.certificates.init() # # initialises the env 
 {
-  if [ -f "~/.once" ]; then
+  if [ -f ~/".once" ]; then
     source ~/.once
     source $ONCE_DEFAULT_SCENARIO/.once
     source $ONCE_DEFAULT_SCENARIO/scenario.map

--- a/init/once
+++ b/init/once
@@ -2606,7 +2606,7 @@ function once.deprecated.ssh.init() #
     exit $?
   fi
   
-  if [ ! -f "~/.ssh/id_rsa" ]; then
+  if [ ! -f ~/".ssh/id_rsa" ]; then
     eamd oinit ssh
   fi
 }
@@ -3176,7 +3176,7 @@ function links.fix() # checks that the once and once.sh are links to the latest 
     return
   fi
   if [ "$DIR" = "/usr/local/sbin" ]; then
-    DIR="~/scripts"
+    DIR=~/"scripts"
   fi
   
   warn.log "fixing links in $DIR"

--- a/init/oosh
+++ b/init/oosh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env -iS HOME=${HOME} bash
 #http://www.etalabs.net/sh_tricks.html
 
 export PS4='sh debug> '
@@ -32,8 +32,8 @@ oosh_check_pm()             # checks for a package manager
     if [ -z "$packageManagerCommand" ]; then
         package=$packageManager
     fi   
-    if ! [ -x "$(command -v $packageManagerCommand)" ]; then
-        log "no $packageManagerCommand"
+    if ! [ -x "$(command -v $packageManager)" ]; then
+        log "no $packageManager"
     else
         if [ -z "$OOSH_PM" ]; then
             export OOSH_PM="$packageManagerCommand"

--- a/init/oosh
+++ b/init/oosh
@@ -1,4 +1,4 @@
-#!/usr/bin/env -iS HOME=${HOME} bash
+#!/usr/bin/env -iS HOME=${HOME} sh
 #http://www.etalabs.net/sh_tricks.html
 
 export PS4='sh debug> '

--- a/line
+++ b/line
@@ -670,7 +670,11 @@ line.format.force.update() # # be carefull. if you added formats manually, they 
 line.start() { # # 
   #echo "sourcing init"
   source this
-   
+
+  if [ -z "$CONFIG_PATH" ]; then
+    source $OOSH_DIR/config
+  fi
+
   line.init
   source $CONFIG_PATH/lineFormat.env
 

--- a/ossh
+++ b/ossh
@@ -490,7 +490,7 @@ ossh.config.parse.url() {  # <url>  <?method> # parses the url and shows config 
   fi
   
   if [ -z "$id" ]; then
-    local id="~/.ssh/id_rsa"
+    local id=~/".ssh/id_rsa"
   fi
 
   private.config.create

--- a/test/test.tilde
+++ b/test/test.tilde
@@ -1,0 +1,46 @@
+#!/bin/sh
+# http://www.etalabs.net/sh_tricks.html
+
+# home dir test
+if [ ~ != "${HOME}" ]; then
+  echo "Tilde expansion differs HOME var .. exit"
+  exit 1
+fi
+
+expand_tilde() {
+    tilde_less="${1#\~/}"
+    [ "$1" != "$tilde_less" ] && tilde_less="$HOME/$tilde_less"
+    printf '%s' "$tilde_less"
+}
+
+# tilde is not expanded in string as defined by POSIX https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_01
+echo "Tilde expansion in string                  : ~/.ssh"
+# tilde is expanded in string with custom function
+echo "Tilde expansion in string w/ expand_tilde():" $(expand_tilde "~/.ssh")
+# tilde is expanded when put before string
+echo "Tilde expansion before string              :" ~/".ssh"
+# do the same with $HOME
+echo "Content of home variable                   : ${HOME}/.ssh"
+
+# tilde expansion in tests
+touch ~/.tilde_expansion
+
+if [ -f "~/.tilde_expansion" ]; then
+  echo "Unexpected success testing tilde expansion in string :O"
+else
+  echo "Testing tilde expansion in string failed as expected ;)"
+fi
+
+if [ -f ~/".tilde_expansion" ]; then
+  echo "Testing tilde expansion succeeds as expected ;)"
+else
+  echo "Unexpected failure testing tilde expansion :O"
+fi
+
+if [ -f $(expand_tilde "~/.tilde_expansion") ]; then
+  echo "Testing tilde expansion succeeds as expected ;)"
+else
+  echo "Unexpected failure testing tilde expansion :O"
+fi
+
+rm ~/.tilde_expansion

--- a/test/test.tilde
+++ b/test/test.tilde
@@ -1,11 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env -iS HOME=${HOME} bash
 # http://www.etalabs.net/sh_tricks.html
-
-# home dir test
-if [ ~ != "${HOME}" ]; then
-  echo "Tilde expansion differs HOME var .. exit"
-  exit 1
-fi
 
 expand_tilde() {
     tilde_less="${1#\~/}"
@@ -13,34 +7,45 @@ expand_tilde() {
     printf '%s' "$tilde_less"
 }
 
-# tilde is not expanded in string as defined by POSIX https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_01
-echo "Tilde expansion in string                  : ~/.ssh"
-# tilde is expanded in string with custom function
-echo "Tilde expansion in string w/ expand_tilde():" $(expand_tilde "~/.ssh")
-# tilde is expanded when put before string
-echo "Tilde expansion before string              :" ~/".ssh"
-# do the same with $HOME
-echo "Content of home variable                   : ${HOME}/.ssh"
+test_start() 
+{
+  # home dir test
+  if [ ~ != "${HOME}" ]; then
+    echo "Tilde expansion differs HOME var .. exit"
+    exit 1
+  fi
 
-# tilde expansion in tests
-touch ~/.tilde_expansion
+  # tilde is not expanded in string as defined by POSIX https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_01
+  echo "Tilde expansion in string                  : ~/.ssh"
+  # tilde is expanded in string with custom function
+  echo "Tilde expansion in string w/ expand_tilde():" $(expand_tilde "~/.ssh")
+  # tilde is expanded when put before string
+  echo "Tilde expansion before string              :" ~/".ssh"
+  # do the same with $HOME
+  echo "Content of home variable                   : ${HOME}/.ssh"
 
-if [ -f "~/.tilde_expansion" ]; then
-  echo "Unexpected success testing tilde expansion in string :O"
-else
-  echo "Testing tilde expansion in string failed as expected ;)"
-fi
+  # tilde expansion in tests
+  touch ~/.tilde_expansion
 
-if [ -f ~/".tilde_expansion" ]; then
-  echo "Testing tilde expansion succeeds as expected ;)"
-else
-  echo "Unexpected failure testing tilde expansion :O"
-fi
+  if [ -f "~/.tilde_expansion" ]; then
+    echo "Unexpected success testing tilde expansion in string :O"
+  else
+    echo "Testing tilde expansion in string failed as expected ;)"
+  fi
 
-if [ -f $(expand_tilde "~/.tilde_expansion") ]; then
-  echo "Testing tilde expansion succeeds as expected ;)"
-else
-  echo "Unexpected failure testing tilde expansion :O"
-fi
+  if [ -f ~/".tilde_expansion" ]; then
+    echo "Testing tilde expansion succeeds as expected ;)"
+  else
+    echo "Unexpected failure testing tilde expansion :O"
+  fi
 
-rm ~/.tilde_expansion
+  if [ -f $(expand_tilde "~/.tilde_expansion") ]; then
+    echo "Testing tilde expansion succeeds as expected ;)"
+  else
+    echo "Unexpected failure testing tilde expansion :O"
+  fi
+
+  rm ~/.tilde_expansion
+}
+
+test_start "$@"

--- a/test/test.tilde
+++ b/test/test.tilde
@@ -10,8 +10,8 @@ expand_tilde() {
 test_start() 
 {
   # home dir test
-  if [ ~ != "${HOME}" ]; then
-    echo "Tilde expansion differs HOME var .. exit"
+  if [ ~ != ${HOME} ]; then
+    echo "Tilde expansion ('" ~ "') differs HOME ('${HOME}') .. exit"
     exit 1
   fi
 


### PR DESCRIPTION
Trying to fix wrong handling of tilde expansion according to [discussion](https://unix.stackexchange.com/questions/151850/why-doesnt-the-tilde-expand-inside-double-quotes) and move clean environment calls into shebang of script `init/oosh`. This GNU [documentation](https://www.gnu.org/software/coreutils/manual/html_node/env-invocation.html#env-invocation) for `env` invocation is giving some more insights.

The script test.tilde for testing the correct behaviour was created, but isn't in the expected structure for usage with test.suite.

Without this fix the installation creates scripts outside the root folder (meaning on /) and the resulting installation is faulty. This is the error indicator:

```
sh debug> cd ~
init/oosh: 133: cd: can't cd to ~
```