### PR TITLE
Merge 'fix/dev' into 'dev'

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Unified shell environment for UCP components and ONCE the Object Network Communi
 
 This Repo consists of two main topics
 1. The oosh object oriented bash envitonment with completion, logging and debugging
-1. the once bash script to manage a ONCE installation into eny environment
+1. the once bash script to manage a ONCE installation into any environment
 1. 1. Supportetd envionments currently are
     * Mac OS
     * Ubuntu

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This Repo consists of two main topics
 
 | Method    | Command                                                                                           |
 |:----------|:--------------------------------------------------------------------------------------------------|
-| **curl**  | `env -i sh -c "$(curl -fsSL https://raw.githubusercontent.com/Cerulean-Circle-GmbH/once.sh/main/init/oosh)"` |
-| **wget**  | `env -i sh -c "$(wget -O- https://raw.githubusercontent.com/Cerulean-Circle-GmbH/once.sh/main/init/oosh)"`   |
-| **fetch** | `env -i sh -c "$(fetch -o - https://raw.githubusercontent.com/Cerulean-Circle-GmbH/once.sh/main/init/oosh)"` |
+| **curl**  | `sh -c "$(curl -fsSL https://raw.githubusercontent.com/Cerulean-Circle-GmbH/once.sh/main/init/oosh)"` |
+| **wget**  | `sh -c "$(wget -O- https://raw.githubusercontent.com/Cerulean-Circle-GmbH/once.sh/main/init/oosh)"`   |
+| **fetch** | `sh -c "$(fetch -o - https://raw.githubusercontent.com/Cerulean-Circle-GmbH/once.sh/main/init/oosh)"` |
 
 ## manual install
 ```

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cat oosh | sh -x
 ```
 sudo apt update
 sudo apt install curl
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/Cerulean-Circle-GmbH/once.sh/main/init/oosh)
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/Cerulean-Circle-GmbH/once.sh/main/init/oosh)"
 
 or as root
 

--- a/backup
+++ b/backup
@@ -16,7 +16,7 @@ $0
   Usage:
   $this: command   description and Parameter
 
-      usage     prints this dialog while it will print the status when tehere are no parameters          
+      usage     prints this dialog while it will print the status when there are no parameters          
       v         print version information
       
       list

--- a/certificates
+++ b/certificates
@@ -72,7 +72,7 @@ certificates.once.get.certbot.path() # # gets the path of the once certificat sc
 
 private.certificates.init() # # initialises the env 
 {
-  if [ -f "~/.once" ]; then
+  if [ -f ~/".once" ]; then
     source ~/.once
     source $ONCE_DEFAULT_SCENARIO/.once
     source $ONCE_DEFAULT_SCENARIO/scenario.map

--- a/config
+++ b/config
@@ -217,8 +217,8 @@ config.string.quote() { # <string> # quote the string to be used as a command li
 
 config.init() # # inititalizes the $CONFIG environment if $CONFIG is empty
 {
-  CONFIG_PATH=~/config
-  CONFIG_FILE=user.env
+  export CONFIG_PATH=~/config
+  export CONFIG_FILE=user.env
 
   if [ ! -d $CONFIG_PATH ]; then
     mkdir $CONFIG_PATH

--- a/config
+++ b/config
@@ -294,8 +294,8 @@ config.save() # <?name> <?ENV_PREFIX> # creates an "<name>.env" config file in $
   RESULT=""
   {    
     #declare -p | grep "^\(declare -[^a]* \)*\([^ ]*$name\)\(.*\)=" | sed 's/^\(declare -.* \)*\((.*'$name'\)\(.*\)=\(.*\)/export \2\3=\4/'
-    #declare -p | grep "^\(declare -[^aA]* \)*\([^ ]*$name\)\(.*\)=" | sed 's/^\(declare -.* \)\(.*'$name'\)\(.*\)=\(.*\)/export \2\3=\4/'
-    declare -p | grep "^\(declare -[^aA]* \)*\([^ ]*$name\)\(.*\)=" | sed 's/^\(.*'$name'\)\(.*\)=\(.*\)/export \1\2=\3/'
+    declare -p | grep "^\(declare -[^aA]* \)*\([^ ]*$name\)\(.*\)=" | sed 's/^\(declare -.* \)\(.*'$name'\)\(.*\)=\(.*\)/export \2\3=\4/'
+    #declare -p | grep "^\(declare -[^aA]* \)*\([^ ]*$name\)\(.*\)=" | sed 's/^\(.*'$name'\)\(.*\)=\(.*\)/export \1\2=\3/'
   } >$CONFIG
 
   if [ -z "$file" ]; then

--- a/config
+++ b/config
@@ -515,7 +515,7 @@ function config.folder.create() # <folderName> # (internal deprecated) creates r
     fi
 }
 
-config.ssh.set.config.host() # <sshConfigName> # configures the PROPT and the name of this host for ssh config
+config.ssh.set.config.host() # <sshConfigName> # configures the PROMPT and the name of this host for ssh config
 { 
   export OOSH_SSH_CONFIG_HOST=$1
   config.save

--- a/config
+++ b/config
@@ -440,7 +440,7 @@ config.file() # <configfile> # sets the default config file to <configfile> if i
   fi
 }
 
-config.location() # <configfile> # sets the default config lcoation to <configfile> if it exists
+config.location() # <configfile> # sets the default config location to <configfile> if it exists
 # if <?option> is "reset", it sets the $CONFIG_FILE backi to user.env
 {
   if [ -z "$1" ]; then

--- a/demo
+++ b/demo
@@ -16,7 +16,7 @@ $0
   Usage:
   $this: command   description and Parameter
 
-      usage     prints this dialog while it will print the status when tehere are no parameters          
+      usage     prints this dialog while it will print the status when there are no parameters          
       v         print version information
       init      initializes ...nothing yet
   

--- a/disk
+++ b/disk
@@ -16,7 +16,7 @@ disk.usage()
   Usage:
   $this: command   description and Parameter
 
-      usage     prints this dialog while it will print the status when tehere are no parameters          
+      usage     prints this dialog while it will print the status when there are no parameters          
       v         print version information
       init      initializes ...nothing yet
 

--- a/index
+++ b/index
@@ -16,7 +16,7 @@ $0
   Usage:
   $this: command   description and Parameter
 
-      usage     prints this dialog while it will print the status when tehere are no parameters          
+      usage     prints this dialog while it will print the status when there are no parameters          
       v         print version information
       init      initializes ...nothing yet
   

--- a/init/once
+++ b/init/once
@@ -2606,7 +2606,7 @@ function once.deprecated.ssh.init() #
     exit $?
   fi
   
-  if [ ! -f "~/.ssh/id_rsa" ]; then
+  if [ ! -f ~/".ssh/id_rsa" ]; then
     eamd oinit ssh
   fi
 }
@@ -3176,7 +3176,7 @@ function links.fix() # checks that the once and once.sh are links to the latest 
     return
   fi
   if [ "$DIR" = "/usr/local/sbin" ]; then
-    DIR="~/scripts"
+    DIR=~/"scripts"
   fi
   
   warn.log "fixing links in $DIR"

--- a/init/oosh
+++ b/init/oosh
@@ -129,6 +129,7 @@ oosh_install_oosh()
 {
 
   oosh_cmd git
+  oosh_cmd rsync
   cd ~
   #if [ -z "$OOSH_DIR" ]; then
     OOSH_DIR="$(pwd)/oosh"
@@ -276,6 +277,9 @@ oosh_start()
   # if [ -r /root ]; then
   #   cd /root
   # fi
+
+  # for testing: Docker install from OOSH_INSTALL_SOURCE
+  # export OOSH_INSTALL_SOURCE=/opt/once.sh
 
   oosh_get_running_shell
   oosh_parse_shellps $SHELLPS

--- a/init/oosh
+++ b/init/oosh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env -iS HOME=${HOME} bash
 #http://www.etalabs.net/sh_tricks.html
 
 export PS4='sh debug> '
@@ -32,8 +32,8 @@ oosh_check_pm()             # checks for a package manager
     if [ -z "$packageManagerCommand" ]; then
         package=$packageManager
     fi   
-    if ! [ -x "$(command -v $packageManagerCommand)" ]; then
-        log "no $packageManagerCommand"
+    if ! [ -x "$(command -v $packageManager)" ]; then
+        log "no $packageManager"
     else
         if [ -z "$OOSH_PM" ]; then
             export OOSH_PM="$packageManagerCommand"

--- a/init/oosh
+++ b/init/oosh
@@ -1,4 +1,4 @@
-#!/usr/bin/env -iS HOME=${HOME} bash
+#!/usr/bin/env -iS HOME=${HOME} sh
 #http://www.etalabs.net/sh_tricks.html
 
 export PS4='sh debug> '

--- a/line
+++ b/line
@@ -670,7 +670,11 @@ line.format.force.update() # # be carefull. if you added formats manually, they 
 line.start() { # # 
   #echo "sourcing init"
   source this
-   
+
+  if [ -z "$CONFIG_PATH" ]; then
+    source $OOSH_DIR/config
+  fi
+
   line.init
   source $CONFIG_PATH/lineFormat.env
 

--- a/line
+++ b/line
@@ -284,7 +284,7 @@ line.table() { # <?seperator:";"> <?heading:" ">  # prints a table (standad for 
 
 line.format()  # <?format> <argumentList> # formats the inputed argumentList
 # <?format> can be either a printf command line
-# or        a predifined name from $CONFIG_PATH/lineFormat.env
+# or        a predefined name from $CONFIG_PATH/lineFormat.env
 #
 # if a format does not exist user: line format.force.update
 # to recreate the file... be aware if you would loose cutom formats you added yourself
@@ -678,7 +678,9 @@ line.start() { # #
   fi
 
   line.init
-  source $CONFIG_PATH/lineFormat.env
+  if [ -f $CONFIG_PATH/lineFormat.env ]; then
+    source $CONFIG_PATH/lineFormat.env
+  fi
 
   # if [ -z "$1" ]; then
   #   status.discover "$@"

--- a/map
+++ b/map
@@ -16,7 +16,7 @@ $0
   Usage:
   $this: command   description and Parameter
 
-      usage     prints this dialog while it will print the status when tehere are no parameters          
+      usage     prints this dialog while it will print the status when there are no parameters          
       v         print version information
       init      initializes ...nothing yet
   

--- a/oo
+++ b/oo
@@ -140,7 +140,7 @@ oo.commit() # # commits latest changes to the oosh environment and publishes the
   cd $OOSH_DIR
 
   local branch=$( git branch | line find "\*" )
-  console.log "git barnch is: $branch"
+  console.log "git branch is: $branch"
   if [ "$branch" = "* dev" ]; then
     rm *\:
     git add *

--- a/oo
+++ b/oo
@@ -311,7 +311,7 @@ oo.branches.check() # <featureBranchPrefix> <baseBranch> <startCommit> # show st
   done
 }
 
-oo.state() # # initializes the stae machine or shows the current state if already initialized
+oo.state() # # initializes the state machine or shows the current state if already initialized
 {
   local machine=SETUP_SERVER
 

--- a/oo
+++ b/oo
@@ -1151,7 +1151,7 @@ oo.usage()
   Usage:
   $this: command   description and Parameter
 
-      usage     prints this dialog while it will print the status when tehere are no parameters          
+      usage     prints this dialog while it will print the status when there are no parameters          
       ----      --------------------------"
   this.help
   echo "

--- a/ossh
+++ b/ossh
@@ -490,7 +490,7 @@ ossh.config.parse.url() {  # <url>  <?method> # parses the url and shows config 
   fi
   
   if [ -z "$id" ]; then
-    local id="~/.ssh/id_rsa"
+    local id=~/".ssh/id_rsa"
   fi
 
   private.config.create

--- a/osx
+++ b/osx
@@ -16,7 +16,7 @@ $0
   Usage:
   $this: command   description and Parameter
 
-      usage     prints this dialog while it will print the status when tehere are no parameters          
+      usage     prints this dialog while it will print the status when there are no parameters          
       v         print version information
       init      initializes ...nothing yet
 

--- a/osx
+++ b/osx
@@ -24,7 +24,7 @@ $0
       alias.show.target       <alias>
       alias.to.link           <alias>   creates a unix symbolic link for the alias
 
-      spotligt                use completion
+      spotlight                use completion
   
   Examples
     $this v

--- a/path
+++ b/path
@@ -16,7 +16,7 @@ $0
   Usage:
   $this: command   description and Parameter
 
-      usage        prints this dialog while it will print the status when tehere are no parameters       
+      usage        prints this dialog while it will print the status when there are no parameters       
 
       status       checks the OOSH and ONCE cofiguration
       env          prints the environment variable and updates result.env

--- a/replace
+++ b/replace
@@ -102,7 +102,7 @@ $0
   Usage:
   $this: in filename expressin by relpaceExpression
 
-      usage             prints this dialog while it will print the status when tehere are no parameters          
+      usage             prints this dialog while it will print the status when there are no parameters          
       v                 print version information
       commit            filename
       rollback          filename

--- a/snet
+++ b/snet
@@ -16,7 +16,7 @@ $0
   Usage:
   $this: command   description and Parameter
 
-      usage     prints this dialog while it will print the status when tehere are no parameters          
+      usage     prints this dialog while it will print the status when there are no parameters          
       v         print version information
       init      initializes ...nothing yet
   

--- a/status
+++ b/status
@@ -88,7 +88,7 @@ $0
   Usage:
   $this: command   description and Parameter
 
-      usage     prints this dialog while it will print the status when tehere are no parameters          
+      usage     prints this dialog while it will print the status when there are no parameters          
       v         print version information
       init      initializes a new user config  
   

--- a/test/test.tilde
+++ b/test/test.tilde
@@ -1,0 +1,46 @@
+#!/bin/sh
+# http://www.etalabs.net/sh_tricks.html
+
+# home dir test
+if [ ~ != "${HOME}" ]; then
+  echo "Tilde expansion differs HOME var .. exit"
+  exit 1
+fi
+
+expand_tilde() {
+    tilde_less="${1#\~/}"
+    [ "$1" != "$tilde_less" ] && tilde_less="$HOME/$tilde_less"
+    printf '%s' "$tilde_less"
+}
+
+# tilde is not expanded in string as defined by POSIX https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_01
+echo "Tilde expansion in string                  : ~/.ssh"
+# tilde is expanded in string with custom function
+echo "Tilde expansion in string w/ expand_tilde():" $(expand_tilde "~/.ssh")
+# tilde is expanded when put before string
+echo "Tilde expansion before string              :" ~/".ssh"
+# do the same with $HOME
+echo "Content of home variable                   : ${HOME}/.ssh"
+
+# tilde expansion in tests
+touch ~/.tilde_expansion
+
+if [ -f "~/.tilde_expansion" ]; then
+  echo "Unexpected success testing tilde expansion in string :O"
+else
+  echo "Testing tilde expansion in string failed as expected ;)"
+fi
+
+if [ -f ~/".tilde_expansion" ]; then
+  echo "Testing tilde expansion succeeds as expected ;)"
+else
+  echo "Unexpected failure testing tilde expansion :O"
+fi
+
+if [ -f $(expand_tilde "~/.tilde_expansion") ]; then
+  echo "Testing tilde expansion succeeds as expected ;)"
+else
+  echo "Unexpected failure testing tilde expansion :O"
+fi
+
+rm ~/.tilde_expansion

--- a/test/test.tilde
+++ b/test/test.tilde
@@ -1,11 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env -iS HOME=${HOME} bash
 # http://www.etalabs.net/sh_tricks.html
-
-# home dir test
-if [ ~ != "${HOME}" ]; then
-  echo "Tilde expansion differs HOME var .. exit"
-  exit 1
-fi
 
 expand_tilde() {
     tilde_less="${1#\~/}"
@@ -13,34 +7,45 @@ expand_tilde() {
     printf '%s' "$tilde_less"
 }
 
-# tilde is not expanded in string as defined by POSIX https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_01
-echo "Tilde expansion in string                  : ~/.ssh"
-# tilde is expanded in string with custom function
-echo "Tilde expansion in string w/ expand_tilde():" $(expand_tilde "~/.ssh")
-# tilde is expanded when put before string
-echo "Tilde expansion before string              :" ~/".ssh"
-# do the same with $HOME
-echo "Content of home variable                   : ${HOME}/.ssh"
+test_start() 
+{
+  # home dir test
+  if [ ~ != "${HOME}" ]; then
+    echo "Tilde expansion differs HOME var .. exit"
+    exit 1
+  fi
 
-# tilde expansion in tests
-touch ~/.tilde_expansion
+  # tilde is not expanded in string as defined by POSIX https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_06_01
+  echo "Tilde expansion in string                  : ~/.ssh"
+  # tilde is expanded in string with custom function
+  echo "Tilde expansion in string w/ expand_tilde():" $(expand_tilde "~/.ssh")
+  # tilde is expanded when put before string
+  echo "Tilde expansion before string              :" ~/".ssh"
+  # do the same with $HOME
+  echo "Content of home variable                   : ${HOME}/.ssh"
 
-if [ -f "~/.tilde_expansion" ]; then
-  echo "Unexpected success testing tilde expansion in string :O"
-else
-  echo "Testing tilde expansion in string failed as expected ;)"
-fi
+  # tilde expansion in tests
+  touch ~/.tilde_expansion
 
-if [ -f ~/".tilde_expansion" ]; then
-  echo "Testing tilde expansion succeeds as expected ;)"
-else
-  echo "Unexpected failure testing tilde expansion :O"
-fi
+  if [ -f "~/.tilde_expansion" ]; then
+    echo "Unexpected success testing tilde expansion in string :O"
+  else
+    echo "Testing tilde expansion in string failed as expected ;)"
+  fi
 
-if [ -f $(expand_tilde "~/.tilde_expansion") ]; then
-  echo "Testing tilde expansion succeeds as expected ;)"
-else
-  echo "Unexpected failure testing tilde expansion :O"
-fi
+  if [ -f ~/".tilde_expansion" ]; then
+    echo "Testing tilde expansion succeeds as expected ;)"
+  else
+    echo "Unexpected failure testing tilde expansion :O"
+  fi
 
-rm ~/.tilde_expansion
+  if [ -f $(expand_tilde "~/.tilde_expansion") ]; then
+    echo "Testing tilde expansion succeeds as expected ;)"
+  else
+    echo "Unexpected failure testing tilde expansion :O"
+  fi
+
+  rm ~/.tilde_expansion
+}
+
+test_start "$@"

--- a/test/test.tilde
+++ b/test/test.tilde
@@ -10,8 +10,8 @@ expand_tilde() {
 test_start() 
 {
   # home dir test
-  if [ ~ != "${HOME}" ]; then
-    echo "Tilde expansion differs HOME var .. exit"
+  if [ ~ != ${HOME} ]; then
+    echo "Tilde expansion ('" ~ "') differs HOME ('${HOME}') .. exit"
     exit 1
   fi
 

--- a/this
+++ b/this
@@ -9,8 +9,8 @@ if [ -n "$SH_OPT" ]; then set $SH_OPT; fi # force debug
 
 if [ -z "$LOG_LEVEL" ]; then
   export LOG_LEVEL=3
-  export LOG_DEVICE=/dev/stdout
-  #export LOG_DEVICE=/dev/tty
+  #export LOG_DEVICE=/dev/stdout
+  export LOG_DEVICE=/dev/tty
 fi
 
 

--- a/user
+++ b/user
@@ -624,7 +624,7 @@ $0
   Usage:
   $this: command   description and Parameter
 
-      usage                   prints this dialog while it will print the status when tehere are no parameters          
+      usage                   prints this dialog while it will print the status when there are no parameters          
       v                       print version information
 
       in 


### PR DESCRIPTION
I ran into several problems trying to install `oosh` into a docker container. The *dev-branch* is checked out and used for installation by the oosh installer, so I injected my cloned repo locally as **OOSH_INSTALL_SOURCE** in the docker container (as mounted volume to path `/opt/once.sh`) by using `export OOSH_INSTALL_SOURCE=/opt/once.sh` in the oosh script:

This PR includes:

- merge 'main' into 'dev' (includes fix/typo)
- merge 'fix/tilde-expansion' into 'dev'
- fix: ERROR> line 677: "source" from /root/oosh/line returned with ERROR code: EPERM 1 Operation not permitted
- fix: Config flaws which interrupts installation. And some typos..
